### PR TITLE
Fix autosell depositing incorrect amount

### DIFF
--- a/src/main/java/unprotesting/com/github/events/AutosellProfitEvent.java
+++ b/src/main/java/unprotesting/com/github/events/AutosellProfitEvent.java
@@ -50,7 +50,7 @@ public class AutosellProfitEvent extends AutoTuneEvent {
                 double price = shop.getSellPrice();
                 double total = price * amount;
                 OfflinePlayer player = Bukkit.getOfflinePlayer(entry.getKey());
-                EconomyUtil.getEconomy().depositPlayer(player, entry.getValue());
+                EconomyUtil.getEconomy().depositPlayer(player, total);
                 ShopUtil.addTransaction(new Transaction(
                         price, amount, entry.getKey(), s, TransactionType.SELL));
                 EconomyDataUtil.increaseEconomyData("GDP", total / 2);


### PR DESCRIPTION
Autosell was depositing the amount of an item sold instead of the total amount it sold for, small change to fix that