### PR TITLE
fix: three critical bugs on rewrite-2 (hash mismatch, autosell armor slots, loan exploit)

### DIFF
--- a/src/main/java/com/noahblclarkson/autotune/command/LoanCommand.java
+++ b/src/main/java/com/noahblclarkson/autotune/command/LoanCommand.java
@@ -97,6 +97,11 @@ public class LoanCommand {
             return;
         }
 
+        if (amount <= 0) {
+            sender.sendMessage(configManager.getMessage("general.invalid-amount"));
+            return;
+        }
+
         AutoTuneConfig.LoanConfig config = configManager.getConfig().loans();
         int clampedDays = Math.max(config.minTermDays(), Math.min(days, config.maxTermDays()));
 
@@ -136,6 +141,12 @@ public class LoanCommand {
             sender.sendMessage(configManager.getMessage("general.player-only"));
             return;
         }
+
+        if (amount <= 0) {
+            sender.sendMessage(configManager.getMessage("general.invalid-amount"));
+            return;
+        }
+
         loanManager.repayLoanAsync(player, BigDecimal.valueOf(amount)).thenAccept(result ->
                 databaseManager.runOnMain(() -> {
                     if (result == null) {

--- a/src/main/java/com/noahblclarkson/autotune/economy/LoanManager.java
+++ b/src/main/java/com/noahblclarkson/autotune/economy/LoanManager.java
@@ -118,6 +118,10 @@ public class LoanManager {
             return LoanResult.error("Loans are disabled");
         }
 
+        if (amount.compareTo(BigDecimal.ZERO) <= 0) {
+            return LoanResult.error("Loan amount must be positive");
+        }
+
         int clampedTerm = Math.max(config.minTermDays(), Math.min(termDays, config.maxTermDays()));
 
         PlayerData playerData = playerRepository.getOrCreate(playerId, playerName);
@@ -155,6 +159,10 @@ public class LoanManager {
     }
 
     public CompletableFuture<LoanResult> repayLoanAsync(@NotNull Player player, @NotNull BigDecimal amount) {
+        if (amount.compareTo(BigDecimal.ZERO) <= 0) {
+            return CompletableFuture.completedFuture(LoanResult.error("Repayment amount must be positive"));
+        }
+
         UUID playerId = player.getUniqueId();
         String playerName = player.getName();
 
@@ -182,8 +190,6 @@ public class LoanManager {
                             return;
                         }
 
-                        BigDecimal overpayment = amount.subtract(loan.currentBalance()).max(BigDecimal.ZERO);
-
                         Loan updated = loan.makePayment(paymentAmount);
                         databaseManager.runAsync(() -> {
                                     loanRepository.update(updated);
@@ -194,13 +200,7 @@ public class LoanManager {
                                                 Math.min(PlayerData.MAX_CREDIT_SCORE, playerData.creditScore() + creditBonus));
                                     }
                                 })
-                                .thenRun(() -> {
-                                    if (overpayment.compareTo(BigDecimal.ZERO) > 0) {
-                                        databaseManager.runOnMain(() ->
-                                                economy.depositPlayer(player, overpayment.doubleValue()));
-                                    }
-                                    future.complete(LoanResult.repaymentSuccess(updated, paymentAmount));
-                                })
+                                .thenRun(() -> future.complete(LoanResult.repaymentSuccess(updated, paymentAmount)))
                                 .exceptionally(ex -> {
                                     plugin.getLogger().log(Level.WARNING, "Failed to process loan repayment", ex);
                                     future.complete(LoanResult.error("Database error"));

--- a/src/main/java/com/noahblclarkson/autotune/listener/AutosellListener.java
+++ b/src/main/java/com/noahblclarkson/autotune/listener/AutosellListener.java
@@ -88,8 +88,12 @@ public class AutosellListener implements Listener {
         int totalSold = 0;
         BigDecimal totalEarned = BigDecimal.ZERO;
 
-        for (int slot = 0; slot < player.getInventory().getSize(); slot++) {
-            ItemStack stack = player.getInventory().getItem(slot);
+        // Use getStorageContents() (slots 0-35) to avoid accidentally iterating
+        // over armor slots (36-39) and the off-hand slot (40) which getSize()
+        // would include for a PlayerInventory.
+        ItemStack[] storageContents = player.getInventory().getStorageContents();
+        for (int slot = 0; slot < storageContents.length; slot++) {
+            ItemStack stack = storageContents[slot];
             if (stack == null || stack.getType().isAir()) {
                 continue;
             }

--- a/src/main/java/com/noahblclarkson/autotune/manager/AutosellManager.java
+++ b/src/main/java/com/noahblclarkson/autotune/manager/AutosellManager.java
@@ -145,8 +145,12 @@ public class AutosellManager {
         int totalSold = 0;
         BigDecimal totalEarned = BigDecimal.ZERO;
 
-        for (int slot = 0; slot < player.getInventory().getSize(); slot++) {
-            ItemStack stack = player.getInventory().getItem(slot);
+        // Use getStorageContents() (slots 0-35) to avoid accidentally iterating
+        // over armor slots (36-39) and the off-hand slot (40) which getSize()
+        // would include for a PlayerInventory.
+        ItemStack[] storageContents = player.getInventory().getStorageContents();
+        for (int slot = 0; slot < storageContents.length; slot++) {
+            ItemStack stack = storageContents[slot];
             if (stack == null || stack.getType().isAir()) {
                 continue;
             }

--- a/src/main/java/com/noahblclarkson/autotune/util/ItemSerializer.java
+++ b/src/main/java/com/noahblclarkson/autotune/util/ItemSerializer.java
@@ -23,6 +23,14 @@ public final class ItemSerializer {
         }
 
         ItemMeta meta = itemStack.getItemMeta();
+
+        // If no distinguishing metadata is present, hash the same way as getMaterialHash()
+        // so that plain vanilla items (which Paper always wraps in an ItemMeta) correctly
+        // resolve to the shop's material-based entries.
+        if (!meta.hasDisplayName() && !meta.hasLore() && !meta.hasEnchants() && !meta.hasCustomModelData()) {
+            return getMaterialHash(itemStack.getType());
+        }
+
         StringBuilder sb = new StringBuilder();
         sb.append(itemStack.getType().name());
 


### PR DESCRIPTION
## Summary

Three independent critical bugs identified by static analysis and fixed.

---

### Bug 1 — ItemSerializer: hash mismatch breaks all shop item lookups for vanilla items

**File:** `util/ItemSerializer.java`

**Root cause:**  
`getMaterialHash(material)` hashes the string `"MATERIAL:" + material.name()` (e.g. `"MATERIAL:STONE"`).  
`getItemHash(stack)` — when the stack *does* have an `ItemMeta` but that meta carries no custom data — hashes just `material.name()` (e.g. `"STONE"`).

Paper 1.21.4 always wraps picked-up vanilla `ItemStack`s in an `ItemMeta` even when the item has no custom NBT data. As a result `getItemHash` and `getMaterialHash` produced different SHA-256 digests for exactly the same plain item, so `ShopManager.getItemByStack()` returned `Optional.empty()` for every default shop entry. This silently broke autosell pickup, the sell GUI, and any other code path that resolved a shop item from a held/inventory stack.

**Fix:** Early-exit to `getMaterialHash()` in `getItemHash()` when the meta carries no distinguishing data (no display name, lore, enchants, or custom model data).

---

### Bug 2 — AutosellManager / AutosellListener: inventory scan includes armor and off-hand slots

**Files:** `manager/AutosellManager.java`, `listener/AutosellListener.java`

**Root cause:**  
Both `AutosellManager.sellInventory()` and `AutosellListener.scanAndSellInventory()` iterated:
```java
for (int slot = 0; slot < player.getInventory().getSize(); slot++) {
    ItemStack stack = player.getInventory().getItem(slot);
```
`PlayerInventory.getSize()` returns 41 in Paper 1.21.4: slots 0–35 are main storage, 36–39 are armor, 40 is off-hand. Any armor piece or off-hand item whose material is registered in the shop (e.g. a diamond chestplate when `DIAMOND` is a shop item) would be matched by `getItemByStack()`, sold for money, and then removed from the armor slot via `setItem(slot, null)`.

**Fix:** Replace the `getSize()`-bounded loop with `getStorageContents()` (returns exactly the 36 main-inventory slots) in both classes. Slot indices from `getStorageContents()` map 1:1 to `setItem(slot, null)`, so item removal is unaffected.

---

### Bug 3 — LoanManager: repayment overpayment exploit + non-positive amount bypass

**Files:** `economy/LoanManager.java`, `command/LoanCommand.java`

**Root cause (exploit):**  
`repayLoanAsync()` capped the withdrawal at `paymentAmount = amount.min(currentBalance)` to avoid charging more than is owed, but then computed:
```java
BigDecimal overpayment = amount.subtract(loan.currentBalance()).max(BigDecimal.ZERO);
// ...
economy.depositPlayer(player, overpayment.doubleValue()); // refunded later
```
When `amount > currentBalance` the player was charged only `currentBalance` but received `amount − currentBalance` as a deposit they never paid. A player with a $300 loan could type `/loan repay 999999` and receive $999,699 in free money while clearing the loan for $300.

**Fix:** Remove the `overpayment` variable and the refund deposit entirely. `paymentAmount` is already capped at `currentBalance`, so there is never a genuine overpayment to refund.

**Root cause (bypass):**  
Neither the command layer nor the manager validated that the supplied amount is positive. A negative value passed the max-loan ceiling check (`negative < maxLoan`) in `requestLoanInternal` and then called `economy.depositPlayer(player, negative)`, which many Vault implementations treat as a withdrawal. Similarly, `/loan repay -500` would pass `economy.has(player, -500)` (always true) and then `economy.withdrawPlayer(player, -500)`, potentially depositing funds.

**Fix:** Guard at the command layer for a fast user-facing rejection, and in the manager as defence-in-depth.

---

## Verification

- `./gradlew compileJava --rerun-tasks` → **BUILD SUCCESSFUL** (15 pre-existing warnings, 0 errors)
- The `buildWeb` task fails on a pre-existing TypeScript type error in `economy-chart.tsx` that is unrelated to this PR.