### PR TITLE
fix: correct loan warning placeholder and overdue vs defaulted message on join

### DIFF
--- a/src/main/java/com/noahblclarkson/autotune/listener/PlayerListener.java
+++ b/src/main/java/com/noahblclarkson/autotune/listener/PlayerListener.java
@@ -81,12 +81,21 @@ public class PlayerListener implements Listener {
         Duration timeUntilDue = Duration.between(Instant.now(), loan.dueDate());
 
         if (timeUntilDue.isNegative()) {
-            player.sendMessage(configManager.getMessage("loan.defaulted",
-                    Map.of("penalty", String.valueOf(configManager.getConfig().loans().defaultPenalty()))));
+            // Loan is past due but not yet processed by the scheduled job (still ACTIVE).
+            // Don't send the "defaulted" message (no credit penalty has been applied yet) —
+            // instead warn that the loan is overdue and will be processed on next tick.
+            player.sendMessage(configManager.getMessage("loan.overdue",
+                    Map.of("amount", configManager.formatCurrency(loan.currentBalance()))));
         } else if (timeUntilDue.toDays() <= 3) {
+            // Format time remaining the same way LoanManager.processWarnings() does,
+            // using the "time_left" key that messages.yml expects.
+            long hoursRemaining = timeUntilDue.toHours();
+            String timeLeft = hoursRemaining >= 24
+                    ? (hoursRemaining / 24) + " day" + (hoursRemaining / 24 != 1 ? "s" : "")
+                    : hoursRemaining + " hour" + (hoursRemaining != 1 ? "s" : "");
             player.sendMessage(configManager.getMessage("loan.warning-due", Map.of(
                     "amount", configManager.formatCurrency(loan.currentBalance()),
-                    "days", String.valueOf(timeUntilDue.toDays())
+                    "time_left", timeLeft
             )));
         }
     }

--- a/src/main/resources/messages.yml
+++ b/src/main/resources/messages.yml
@@ -62,6 +62,7 @@ loan:
   no-active-loan: "<yellow>You don't have any active loans."
   interest-applied: "<yellow>Interest applied to your loan. New balance: <gold><balance></gold>"
   warning-due: "<gold>\u26A0 Your loan balance of <gold><amount></gold> is due in <yellow><time_left></yellow>!"
+  overdue: "<red>\u26A0 Your loan is overdue! Balance: <gold><amount></gold>. Log back in regularly — it will be processed soon."
   defaulted: "<red>Your loan has defaulted! Credit score reduced by <gold><penalty></gold> points."
   credit-score: "<gray>Your credit score: <gold><score></gold>"
 


### PR DESCRIPTION
## What

Two bugs in `PlayerListener.checkLoanWarning()` found during morning audit:

### Bug 1 — Wrong placeholder key in join loan warning

**File:** `PlayerListener.java`

The `warning-due` message template in `messages.yml` uses `<time_left>` as the placeholder:
```
warning-due: "⚠ Your loan balance of <amount> is due in <time_left>!"
```

But `PlayerListener.checkLoanWarning()` was passing `"days"` as the key:
```java
Map.of("amount", ..., "days", String.valueOf(timeUntilDue.toDays()))
```

**Effect:** Players saw the literal text `<time_left>` in their loan warning on join instead of the actual time remaining.

**Fix:** Use `"time_left"` key with formatted time string (same logic as `LoanManager.processWarnings()`).

---

### Bug 2 — Premature "loan has defaulted" message for overdue-but-not-yet-defaulted loans

**File:** `PlayerListener.java`, `messages.yml`

When a loan was past its due date but the scheduled `processOverdueLoans()` tick hadn't run yet (e.g., server was offline), the loan was still `ACTIVE` in the DB. But `checkLoanWarning()` sent the `loan.defaulted` message: *"Your loan has defaulted! Credit score reduced by X points."*

The player saw this alarming message despite no penalty having been applied yet.

**Fix:** 
- Added `loan.overdue` message key: *"⚠ Your loan is overdue! Balance: $X. It will be processed soon."*  
- Use this key when the loan is past due but still ACTIVE (no penalty yet)
- `loan.defaulted` is now only sent by `processOverdueLoans()` when it actually runs